### PR TITLE
Rename master to main to match upstream

### DIFF
--- a/capi_image_builder/args.py
+++ b/capi_image_builder/args.py
@@ -16,7 +16,7 @@ class Args:
     make_image_public: bool = False
 
     # Sane defaults
-    git_branch: str = "master"
+    git_branch: str = "main"
     os_version: str = "2004"
     target_dir: Optional[str] = None
 

--- a/capi_image_builder/builder/git_ops.py
+++ b/capi_image_builder/builder/git_ops.py
@@ -43,14 +43,14 @@ class GitOps:
         """Fetch the upstream remote of a git repo."""
         self.repo.remotes[remote_name].fetch()
 
-    def git_merge_upstream(self, remote_name: str = "upstream", branch: str = "master"):
+    def git_merge_upstream(self, remote_name: str = "upstream", branch: str = "main"):
         """
         Merge the current branch onto the upstream branch to bring fork into sync.
         """
         print(f"Merging {remote_name}/{branch} into current branch")
         self.repo.git.merge(f"{remote_name}/{branch}")
 
-    def git_push(self, remote_name: str = "origin", branch: str = "master"):
+    def git_push(self, remote_name: str = "origin", branch: str = "main"):
         """Push the current branch to the remote."""
         print(f"Pushing current branch to {remote_name}/{branch}")
         self.repo.git.push(remote_name, branch)

--- a/capi_image_builder/main.py
+++ b/capi_image_builder/main.py
@@ -51,8 +51,8 @@ def _parse_args() -> Args:
     )
     parser.add_argument(
         "--git-branch",
-        default="master",
-        help="The branch to build from. Default: master",
+        default="main",
+        help="The branch to build from. Default: main",
     )
     parser.add_argument(
         "--image-name",

--- a/capi_image_builder/test/test_git_ops.py
+++ b/capi_image_builder/test/test_git_ops.py
@@ -117,8 +117,8 @@ def test_git_merge_mock():
     # Patch merge to not actually merge
     ops.repo = mock.MagicMock()
 
-    ops.git_merge_upstream("upstream_merge", "master")
-    ops.repo.git.merge.assert_called_once_with("upstream_merge/master")
+    ops.git_merge_upstream("upstream_merge", "main")
+    ops.repo.git.merge.assert_called_once_with("upstream_merge/main")
 
 
 def test_git_push_mock():


### PR DESCRIPTION
Upstream has renamed their master to main, breaking the CAPI image build. Rename our fork and the upstream references to now reflect this