### PR TITLE
MAINT: Move nfs-common and open-iscsi to build

### DIFF
--- a/cluster-api/ansible_stfc_roles.json
+++ b/cluster-api/ansible_stfc_roles.json
@@ -1,3 +1,4 @@
 {
+    "extra_debs": "nfs-common open-iscsi",
     "firstboot_custom_roles_post": "vm_baseline containerd"
 }


### PR DESCRIPTION
Moves the CAPI packages nfs-common and open-iscsi, which are used potentially by longhorn, into the image build.
This resolves issues where sometimes CAPI clusters would not come up, as the apt-cache didn't refresh before trying to install said package