### PR TITLE
ENH: Add metadata to set metadata for SCSI

### DIFF
--- a/scripts/test/test_upload_all.py
+++ b/scripts/test/test_upload_all.py
@@ -112,6 +112,9 @@ def fake_upload_args_fixture():
             "container_format": "bare",
             "wait": True,
             "visibility": visibility,
+            # Metadata fields
+            "hw_scsi_model": "virtio-scsi",
+            "hw_disk_bus": "scsi",
         }
 
     return _expected_args_helper

--- a/scripts/upload_all.py
+++ b/scripts/upload_all.py
@@ -83,6 +83,9 @@ def upload_images_to_openstack(files: List[Path], args: Args):
             "container_format": "bare",
             "wait": True,
             "visibility": "public" if args.public else "private",
+            # Metadata fields - setting through kwargs invokes automatic type conversion
+            "hw_scsi_model": "virtio-scsi",
+            "hw_disk_bus": "scsi",
         }
         logging.debug("Upload args: %s", upload_args)
         if args.dry_run:


### PR DESCRIPTION
This resolves some issues we were seeing with mounting cinder volumes, so ensure it's set on images built by CAPI

An image which has been uploaded with this script can be found on dev-openstack/admin project with the name `capi-ubuntu-2004-kube-v1.26.14-2024-03-26`

The fields should match the first two lines in these docs: https://docs.ceph.com/en/latest/rbd/rbd-openstack/#image-properties