### PR TITLE
BUG: remove cri-registry.toml

### DIFF
--- a/cluster-api/README.md
+++ b/cluster-api/README.md
@@ -9,7 +9,7 @@ Setup
 - Install Ansible, if the version of Ansible core is too old it can be upgraded with:
 
 ```shell
-sudo apt-get install python3.9-venv -y
+sudo apt-get install python3.9-venv unzip -y
 python3.9 -m venv venv
 source venv/bin/activate
 pip install "ansible" "ansible-core" --upgrade

--- a/cluster-api/roles/containerd/files/cri-registry.toml
+++ b/cluster-api/roles/containerd/files/cri-registry.toml
@@ -1,2 +1,0 @@
-[plugins."io.containerd.grpc.v1.cri".registry]
-   config_path = "/etc/containerd/certs.d"

--- a/cluster-api/roles/containerd/tasks/main.yml
+++ b/cluster-api/roles/containerd/tasks/main.yml
@@ -13,12 +13,6 @@
     dest: /etc/containerd/certs.d/docker.io/hosts.toml
     mode: 0644
 
-- name: Copy config to point CRI to /etc/containerd/certs.d
-  copy:
-    src: cri-registry.toml
-    dest: /etc/containerd/conf.d/cri-registry.toml
-    mode: 0644
-
 - name: Create a file to hold the Nvidia container config
   file:
     path: /etc/containerd/conf.d/nvidia.toml


### PR DESCRIPTION
This is hardcoded in the upstream config.toml - https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml#L14-L15

so we shouldn't set it again - causes "duplicate table" error in our images
