### PR TITLE
Bump K8s CAPI Images

### DIFF
--- a/cluster-api/README.md
+++ b/cluster-api/README.md
@@ -58,7 +58,7 @@ export ANSIBLE_ROLES_PATH="$(pwd)/os_builders/roles:$(pwd)/cluster-api/roles"
 export PACKER_VAR_FILES="$(pwd)/cluster-api/ansible_stfc_roles.json"
 
 # Run build
-make -C k8s-image-builder/images/capi build-qemu-ubuntu-2004
+make -C k8s-image-builder/images/capi build-qemu-ubuntu-2404
 ```
 
 Building a custom version
@@ -75,7 +75,7 @@ export ROLE_DEFINITION="cluster-api/ansible_stfc_roles.json"
 
 export PACKER_VAR_FILES="$(pwd)/${K8S_VERSION} $(pwd)/${ROLE_DEFINITION}"
 
-make -C k8s-image-builder/images/capi build-qemu-ubuntu-2004
+make -C k8s-image-builder/images/capi build-qemu-ubuntu-2404
 ```
 
 Adding a new version

--- a/cluster-api/versions/v1_27.json
+++ b/cluster-api/versions/v1_27.json
@@ -1,5 +1,6 @@
 {
     "kubernetes_series": "v1.27",
-    "kubernetes_semver": "v1.27.15",
-    "kubernetes_deb_version": "1.27.15-1.1"
+    "kubernetes_semver": "v1.27.16",
+    "kubernetes_deb_version": "1.27.16-1.1",
+    "kubernetes_deb_gpg_key": "https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key"
 }

--- a/cluster-api/versions/v1_28.json
+++ b/cluster-api/versions/v1_28.json
@@ -1,5 +1,5 @@
 {
     "kubernetes_series": "v1.28",
-    "kubernetes_semver": "v1.28.12",
-    "kubernetes_deb_version": "1.28.12-1.1"
+    "kubernetes_semver": "v1.28.16",
+    "kubernetes_deb_version": "1.28.16-1.1"
 }

--- a/cluster-api/versions/v1_29.json
+++ b/cluster-api/versions/v1_29.json
@@ -1,5 +1,5 @@
 {
     "kubernetes_series": "v1.29",
-    "kubernetes_semver": "v1.29.7",
-    "kubernetes_deb_version": "1.29.7-1.1"
+    "kubernetes_semver": "v1.29.10",
+    "kubernetes_deb_version": "1.29.10-1.1"
 }

--- a/cluster-api/versions/v1_30.json
+++ b/cluster-api/versions/v1_30.json
@@ -1,5 +1,5 @@
 {
     "kubernetes_series": "v1.30",
-    "kubernetes_semver": "v1.30.3",
-    "kubernetes_deb_version": "1.30.3-1.1"
+    "kubernetes_semver": "v1.30.6",
+    "kubernetes_deb_version": "1.30.6-1.1"
 }

--- a/os_builders/roles/prep_builder/tasks/main.yml
+++ b/os_builders/roles/prep_builder/tasks/main.yml
@@ -28,9 +28,10 @@
 
 - name: Install Packer
   apt:
-    name: packer
+    # K8s-image-builder requires a specific version of packer
+    name: packer=1.9.5-1
     state: present
-
+    allow_downgrade: yes
 
 - name: Add user to required groups
   user:

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1,25 +1,5 @@
 #!/usr/bin/env bash
 set -euxo pipefail
-
-PARALLEL_JOBS=1
-
-while getopts hj: opt; do
-    case ${opt} in
-        h)
-            echo "Usage: $0 [-h]"
-            echo "  -h    Display this help message."
-            echo "  -j    Number of parallel jobs to run, default: 1"
-            exit 0
-            ;;
-        j)
-            PARALLEL_JOBS="${OPTARG}"
-            ;;
-        \?)
-            echo "Invalid option: -${OPTARG}" >&2
-            exit 1
-            ;;
-    esac
-done
 shift $((OPTIND-1))
 
 # Get root of repo based on the location of this script
@@ -35,17 +15,8 @@ shopt -s nullglob  # This forces bash to expand the glob
 VERSIONS=( "${REPO_ROOT}"/cluster-api/versions/*.json )
 
 for version_path in "${VERSIONS[@]}"; do
-    (
-    echo "Building image for version: ${version_path}..."
-    export PACKER_VAR_FILES="${CUSTOM_ROLE_PATH} ${version_path}"
-    make -C "${REPO_ROOT}/k8s-image-builder/images/capi" build-qemu-ubuntu-2004
-    ) &
-    
-    # https://unix.stackexchange.com/a/436713
-    # allow to execute up to $N jobs in parallel
-    if [[ $(jobs -r -p | wc -l) -ge $PARALLEL_JOBS ]]; then
-        # now there are $N jobs already running, so wait here for any job
-        # to be finished so there is a place to start next one.
-        wait -n
-    fi
+    echo "Building image for version: ${version_path}..." && \
+    export PACKER_VAR_FILES="${CUSTOM_ROLE_PATH} ${version_path}" && \
+    make -C "${REPO_ROOT}/k8s-image-builder/images/capi" build-qemu-ubuntu-2004 2>&1 \
+        | tee "${REPO_ROOT}/output/${version_path}.log" &
 done

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -17,6 +17,5 @@ VERSIONS=( "${REPO_ROOT}"/cluster-api/versions/*.json )
 for version_path in "${VERSIONS[@]}"; do
     echo "Building image for version: ${version_path}..." && \
     export PACKER_VAR_FILES="${CUSTOM_ROLE_PATH} ${version_path}" && \
-    make -C "${REPO_ROOT}/k8s-image-builder/images/capi" build-qemu-ubuntu-2004 2>&1 \
-        | tee "${REPO_ROOT}/output/${version_path}.log" &
+    make -C "${REPO_ROOT}/k8s-image-builder/images/capi" build-qemu-ubuntu-2404 &
 done


### PR DESCRIPTION
Bumps the K8s CAPI Images:

- Add a fix for 1.27 builds
- Simplify the build-all.sh script which was causing problems
- Switch to 24.04 :tada: 
- Fix the problems around building that