### PR TITLE
ENH: Enable Qemu Guest Agent

### DIFF
--- a/os_builders/roles/vm_baseline/tasks/qemu-guest-agent.yml
+++ b/os_builders/roles/vm_baseline/tasks/qemu-guest-agent.yml
@@ -9,7 +9,7 @@
   yum:
     name: "qemu-guest-agent"
     state: present
-  when: ansible_distribution == "Rocky"  and "ccm" not in ansible_facts.packages
+  when: ansible_distribution == "Rocky"
 
 - name: Enable Qemu Guest Agent
   ansible.builtin.systemd_service:

--- a/os_builders/roles/vm_baseline/tasks/qemu-guest-agent.yml
+++ b/os_builders/roles/vm_baseline/tasks/qemu-guest-agent.yml
@@ -10,3 +10,9 @@
     name: "qemu-guest-agent"
     state: present
   when: ansible_distribution == "Rocky"  and "ccm" not in ansible_facts.packages
+
+- name: Enable Qemu Guest Agent
+  ansible.builtin.systemd_service:
+    name: qemu-guest-agent.service
+    enabled: true
+    state: started


### PR DESCRIPTION
Enable the service to make sure it starts and boot and is started when the image builds.