### PR TITLE
MAINT: Drop and ccm not in packages

### DIFF
--- a/os_builders/roles/nubes_bootcontext/tasks/main.yml
+++ b/os_builders/roles/nubes_bootcontext/tasks/main.yml
@@ -9,7 +9,7 @@
     owner: root
     group: root
     mode: 0755
-  when: ansible_distribution != "Rocky"  and "ccm" not in ansible_facts.packages
+  when: ansible_distribution != "Rocky" 
 
 - name: Copy in nubes-boot systemd unit
   copy:

--- a/os_builders/roles/vm_baseline/tasks/cron.yml
+++ b/os_builders/roles/vm_baseline/tasks/cron.yml
@@ -10,4 +10,4 @@
   yum:
     name: "cronie"
     state: present
-  when: ansible_distribution == "Rocky"  and "ccm" not in ansible_facts.packages
+  when: ansible_distribution == "Rocky" 

--- a/os_builders/roles/vm_baseline/tasks/openscap.yml
+++ b/os_builders/roles/vm_baseline/tasks/openscap.yml
@@ -24,7 +24,7 @@
   package:
     name: openscap
     state: present
-  when: ansible_distribution == "Rocky"  and "ccm" not in ansible_facts.packages
+  when: ansible_distribution == "Rocky" 
   register: result
   retries: 5
   delay: 30

--- a/os_builders/roles/vm_baseline/tasks/pakiti.yml
+++ b/os_builders/roles/vm_baseline/tasks/pakiti.yml
@@ -42,7 +42,7 @@
     name: "/tmp/pakiti-client-2.1.4-3.RAL.noarch.rpm"
     state: present
     disable_gpg_check: true
-  when: ansible_distribution == "Rocky"  and "ccm" not in ansible_facts.packages
+  when: ansible_distribution == "Rocky" 
 
 - name: Ensure pakiti config directory exists
   file:

--- a/os_builders/roles/vm_baseline/tasks/qemu-guest-agent.yml
+++ b/os_builders/roles/vm_baseline/tasks/qemu-guest-agent.yml
@@ -9,4 +9,4 @@
   yum:
     name: "qemu-guest-agent"
     state: present
-  when: ansible_distribution == "Rocky"  and "ccm" not in ansible_facts.packages
+  when: ansible_distribution == "Rocky" 

--- a/os_builders/roles/vm_baseline/tasks/ukescienceca.yml
+++ b/os_builders/roles/vm_baseline/tasks/ukescienceca.yml
@@ -4,4 +4,4 @@
 
 - name: Install UK eScience Root CA on RL
   ansible.builtin.include_tasks: ukscienceca/install_ukscienceca_rocky.yml
-  when: ansible_distribution == "Rocky" and "ccm" not in ansible_facts.packages
+  when: ansible_distribution == "Rocky"

--- a/os_builders/roles/vm_baseline/tasks/wazuh.yml
+++ b/os_builders/roles/vm_baseline/tasks/wazuh.yml
@@ -14,7 +14,7 @@
 
 - name: Install wazuh on Rocky
   ansible.builtin.include_tasks: wazuh/install_wazuh_rocky.yml
-  when: ansible_distribution == "Rocky" and "ccm" not in ansible_facts.packages
+  when: ansible_distribution == "Rocky"
 
 - name: configure wazuh-agent
   block:


### PR DESCRIPTION
All images should have the same baseline whether or not they are aquilon managed.