### PR TITLE
BUG: Fix typo when removing matrix

### DIFF
--- a/.github/workflows/os_builder.yaml
+++ b/.github/workflows/os_builder.yaml
@@ -26,7 +26,7 @@ jobs:
           run: |
             cd os_builders/packfiles &&
             packer init . &&
-            packer validate .
+            packer validate -syntax-only .
 
   test_image_build_ubuntu:
       strategy:


### PR DESCRIPTION
Matrix was removed as we do not need a matrix of one. But startegy was not removed so the workflow became invalid.