### PR TITLE
ENH: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 ** @stfc/cloud
 os_builders/** @khalford
+os_builders/roles/vm_baseline/** @jacob-ward
 amphora-image-builder/** @DavidFair


### PR DESCRIPTION
Add CODEOWNERS so people from the cloud team are automatically assigned to the pull requests made.

More info about code owners here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners