### PR TITLE
Rename playbook

### DIFF
--- a/.github/workflows/os_builder.yaml
+++ b/.github/workflows/os_builder.yaml
@@ -44,11 +44,11 @@ jobs:
             . venv/bin/activate
             pip3 install --upgrade pip
             pip3 install ansible python-debian
-        - name: Run pre-prep playbook
+        - name: Run configure_os_images playbook
           run: |
-           . venv/bin/activate
-           cd os_builders
-           ansible-playbook prepare_user_image.yml --extra-vars provision_this_machine=True -i ../.github/localhost.yml
+            . venv/bin/activate
+            cd os_builders
+            ansible-playbook configure_os_images.yml -i ../.github/localhost.yml --extra-vars tidy_image=false
 
   test_image_build_rocky:
     strategy:
@@ -63,7 +63,7 @@ jobs:
           dnf install epel-release -y
           # These have to be separate steps as ansible is provided by epel-release
           dnf install ansible -y
-      - name: Run pre-prep playbook
+      - name: Run configure_os_images playbook
         run: |
           cd os_builders
-          ansible-playbook prepare_user_image.yml --extra-vars provision_this_machine=True -i ../.github/localhost.yml
+          ansible-playbook configure_os_images.yml -i ../.github/localhost.yml --extra-vars tidy_image=false

--- a/amphora-image-builder/elements/vm_baseline/install.d/90-run-vm_baseline
+++ b/amphora-image-builder/elements/vm_baseline/install.d/90-run-vm_baseline
@@ -24,7 +24,7 @@ hostname
 sed -i "s/hosts: default/hosts: localhost/g" os_builders/*.yml
 mkdir -p /var/ossec/etc/extra
 echo "{\"groups\": [\"default\", \"cloud\", \"ubuntu\", \"debian\", \"octavia-amphora\"], \"labels\": {\"amphora-build-date\": \"$(date '+%Y-%m-%d %H:%M:%S')\" }}" > /var/ossec/etc/extra/03-amphora.json
-ansible-playbook os_builders/playbooks/prepare_user_image.yml --extra-vars provision_this_machine=true -i os_builders/inventory/localhost.yml
+ansible-playbook os_builders/configure_os_images.yml -i .github/localhost.yml
 echo "130.246.210.20 wazuh.cape.stfc.ac.uk" >> /etc/hosts
 
 apt-get autoremove -y

--- a/os_builders/README.md
+++ b/os_builders/README.md
@@ -108,7 +108,7 @@ The pipeline consists of the following steps:
   ```
 4. Run the baseline against the VM
   ```shell
-  ansible-playbook -i inventory vm_baseline.yml
+  ansible-playbook -i inventory configure_os_images.yml
   ```
 5. Run any other custom playbooks against the VM which you want to test
   ```shell
@@ -124,7 +124,7 @@ os_builders
 ├── build.pkr.hcl  # Packer build file
 ├── galaxy.yml  # Ansible Galaxy collection metadata
 ├── prep_builder.yml  # Playbook to install Packer
-├── prepare_user_image.yml  # Playbook to configure the images
+├── configure_os_images.yml  # Playbook to configure the images
 ├── requirements.txt  # Specifies Ansible version
 └── roles  # Roles to configure the image
     ├── container_registry/

--- a/os_builders/build.pkr.hcl
+++ b/os_builders/build.pkr.hcl
@@ -82,10 +82,8 @@ build {
 
   provisioner "ansible" {
     user          = "${build.User}"
-    playbook_file = "prepare_user_image.yml"
+    playbook_file = "configure_os_images.yml"
     extra_arguments = [
-      # Include safety checks
-      "--extra-vars", "provision_this_machine=true, tidy_image=True",
       # Workaround https://github.com/hashicorp/packer/issues/12416
       # This is required for Ubuntu (Debian) 24.04+ as SFTP is disabled by default
       "--scp-extra-args", "'-O'",

--- a/os_builders/configure_os_images.yml
+++ b/os_builders/configure_os_images.yml
@@ -6,7 +6,7 @@
         msg: "[ERROR] Empty inventory. No host available."
       when: groups.all|length == 0
       
-- name: Prep STFC Cloud User Image
+- name: Prepare the image with the STFC security baseline
   hosts: all
   pre_tasks:
     - name: User warning
@@ -18,4 +18,4 @@
     - role: container_registry
     - role: nubes_bootcontext
     - role: tidy_image
-      when: "{{ tidy_image | default(false) | bool == true }}"
+      when: "{{ tidy_image | default(true) | bool == true }}"


### PR DESCRIPTION
Rename the playbook from prepare_user_image.yml -> vm_baseline.yml as this playbook configures the baseline for our VMs in OpenStack. 
Also removes the extra vars for 2 reasons:
- Remove provision_this_machine as there was no check that actullay uses this. Also, localhost is not implicit in all hosts so you can't run against localhost by mistake
- remove tidy_image as we always want to tidy the image using this playbook. If you want the security baseline but not the itdy image, make a custom playbook with the vm_baseline role