### PR TITLE
Add a line in the README about exporting the cloud account name

### DIFF
--- a/cluster-api/README.md
+++ b/cluster-api/README.md
@@ -38,7 +38,6 @@ The token can be generated from your GitHub settings, under developer access, an
 
 You need to set up credentials for OpenStack authentication as we are using a remote builder. Create a clouds.yaml application credential and place it into `~/.config/openstack/clouds.yaml`. See [here](https://stfc.atlassian.net/wiki/spaces/CLOUDKB/pages/211484774/Application+Credentials) for help.
 
-<<<<<<< HEAD
 Addtionally, you will need to specify the cloud name in your session by exporting it. By default this will be `openstack` as seen in the standard `clouds.yaml` file:
 
 `export OS_CLOUD=<cloud-name>`


### PR DESCRIPTION
This is needed to pass authentication when building the image, even if you only have a single cloud account in your clouds.yaml file.