### PR TITLE
MAINT: Adding the image_fixes role to the CAPI builder

### DIFF
--- a/cluster-api/common_vars.json
+++ b/cluster-api/common_vars.json
@@ -1,6 +1,6 @@
 {
     "extra_debs": "nfs-common open-iscsi",
-    "node_custom_roles_post": "vm_baseline containerd",
+    "node_custom_roles_post": "vm_baseline containerd image_fixes",
     "source_image":  "",
     "source_image_filter_name": "ubuntu-jammy-22.04-nogui",
     "flavor": "l3.nano",


### PR DESCRIPTION
Applies the fix for the NVIDIA PCI I/O invalid device error to our images.