### PR TITLE
fix update_cloud_users script to use new username service

### DIFF
--- a/os_builders/roles/nubes_bootcontext/files/update_cloud_users.sh
+++ b/os_builders/roles/nubes_bootcontext/files/update_cloud_users.sh
@@ -9,53 +9,73 @@ then
     rm -f /var/lock/firstboot
 fi
 
-[[ -d /mnt/context ]] || mkdir /mnt/context
-[[ -d /mnt/context/openstack ]] || mount /dev/sr0 /mnt/context
-INSTANCEID=$(jq .uuid /mnt/context/openstack/latest/meta_data.json | sed "s/\"//g")
-
-if curl -s http://openstack.nubes.rl.ac.uk:9999/cgi-bin/get_username.sh?"$INSTANCEID" | grep ".";
-then
-    OPENSTACK_URL='openstack.nubes.rl.ac.uk'
-else
-    OPENSTACK_URL='dev-openstack.nubes.rl.ac.uk'
+mkdir -p /mnt/context
+if [[ ! -d "/mnt/context/openstack" ]]; then
+    mount /dev/sro /mnt/context
 fi
 
-echo $OPENSTACK_URL
+INSTANCEID=$(jq -r .uuid /mnt/context/openstack/latest/meta_data.json)
 
-FEDID_RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://$OPENSTACK_URL:9999/cgi-bin/get_username.sh?"$INSTANCEID")
-if [[ $FEDID_RESPONSE_CODE != 200 ]]; then
-    echo "$FEDID_RESPONSE_CODE expected 200"
-    exit
-fi
+BASE_URLS=(
+    "https://openstack.stfc.ac.uk"
+    "https://dev-openstack.stfc.ac.uk"
+)
 
-FEDIDS=$(curl -s http://$OPENSTACK_URL:9999/cgi-bin/get_username_list.sh?"$INSTANCEID")
-FEDID=$(curl -s http://$OPENSTACK_URL:9999/cgi-bin/get_username.sh?"$INSTANCEID")
 
-while [ -z "$FEDID" ]
-   do
-    if [ -z "$INSTANCEID" ]
-    then
-        INSTANCEID=$(dmidecode | grep UUID | tr '[:upper:]' '[:lower:]' | sed "s/\\tuuid: //")
+OPENSTACK_URL=""
+for base in  "${BASE_URLS[@]}"; do
+    url="${base}/getusername?serverID=${INSTANCEID}"
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+    if [[ $HTTP_CODE = 200 ]]; then
+        OPENSTACK_URL="$url"
+        break
+    else
+        echo "Error Connecting to ${OPENSTACK_URL}: Expected 200 got ${HTTP_CODE}, trying another"
     fi
-    FEDID=$(curl -s http://$OPENSTACK_URL:9999/cgi-bin/get_username.sh?"$INSTANCEID")
-    ((c++)) && ((c==3)) && c=0 && break
-   done
+done
 
-SSH_PUBLIC_KEY=$(jq .keys[0].data /mnt/context/openstack/latest/meta_data.json | sed "s/\"//g")
+if [[ -z "$OPENSTACK_URL" ]]; then
+    echo "Failed to get valid OpenStack endpoint"
+    exit 1
+fi
+
+
+# --- Fetch FEDID with retries ---
+FEDID=""
+for _ in {1..3}; do
+    FEDID=$(curl -fs "$OPENSTACK_URL" || true)
+
+    if [[ -n "$FEDID" ]]; then
+        break
+    fi
+
+    # fallback to dmidecode if needed
+    if [[ -z "$INSTANCEID" ]]; then
+        INSTANCEID=$(dmidecode | awk -F': ' '/UUID/ {print tolower($2)}')
+    fi
+
+    sleep 1
+done
+
+if [[ -z "$FEDID" ]]; then
+    echo "Failed to retrieve FEDID from ${OPENSTACK_URL}"
+    exit 1
+fi
+
+SSH_PUBLIC_KEY=$(jq -r .keys[0].data /mnt/context/openstack/latest/meta_data.json)
 
 groupadd wheel
 
-for ID in $FEDID $FEDIDS; do
-    id -u "$ID" || useradd "$ID" -g wheel -m -s /bin/bash
-    usermod "$ID" -a -G wheel,cloud
+id -u "$ID" || useradd "$ID" -g wheel -m -s /bin/bash
+usermod "$ID" -a -G wheel,cloud
 
-    [[ -d /home/"$ID"/.ssh ]] || mkdir -p /home/"$ID"/.ssh
-    chown "$ID" /home/"$ID"
-    chown "$ID" /home/"$ID"/.ssh
-    if [[ "$ID" == "$FEDID" ]]; then
-        if ! grep -qF "${SSH_PUBLIC_KEY//\\n/}" /home/"$ID"/.ssh/authorized_keys; then
-            echo "${SSH_PUBLIC_KEY//\\n/}" >> /home/"$ID"/.ssh/authorized_keys
-        fi
+[[ -d /home/"$ID"/.ssh ]] || mkdir -p /home/"$ID"/.ssh
+chown "$ID" /home/"$ID"
+chown "$ID" /home/"$ID"/.ssh
+if [[ "$ID" == "$FEDID" ]]; then
+    if ! grep -qF "${SSH_PUBLIC_KEY//\\n/}" /home/"$ID"/.ssh/authorized_keys; then
+        echo "${SSH_PUBLIC_KEY//\\n/}" >> /home/"$ID"/.ssh/authorized_keys
     fi
-    chown "$ID" /home/"$ID"/.ssh/authorized_keys
-done
+fi
+chown "$ID" /home/"$ID"/.ssh/authorized_keys
+


### PR DESCRIPTION
some QOL and readability fixes.
This will require the username service to be working on dev and prod

Need to test this script once the username service is setup on prod. 
Then we'll need to put in a permanent redirect in haproxy to from the old username service `http://openstack.nubes.rl.ac.uk:9999/cgi-bin/get_username.sh?<vm-id>` -> `https://openstack.stfc.ac.uk:9999/getUsername?serverID?<vm-id>` - same for dev

removed `cgi-bin/get_username_list.sh` endpoint - it wasn't being used

