### PR TITLE
Amphora image builder fixes

### DIFF
--- a/amphora-image-builder/Dockerfile
+++ b/amphora-image-builder/Dockerfile
@@ -1,16 +1,22 @@
 FROM ubuntu:22.04
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    python3-pip python3-virtualenv python3-pkg-resources git sudo \
-    qemu-utils git kpartx debootstrap curl && \
-    apt-get clean all
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        qemu-utils git kpartx debootstrap \
+        python3-pip curl sudo gnupg lsb-release && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
+    
 # Copy this entire git directory, as we may be on a branch with changes we want to include
 # rather than main
 COPY ./ /opt/cloud-image-builders
 
-COPY amphora-image-builder/entrypoint.sh /entrypoint.sh
+# Clone octavia and install its diskimage-create requirements
+RUN git clone https://opendev.org/openstack/octavia.git /opt/octavia \
+ && pip3 install --no-cache-dir -r /opt/octavia/diskimage-create/requirements.txt
+
+COPY amphora-image-builder/entrypoint.sh entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT [ "bash", "/entrypoint.sh" ]

--- a/amphora-image-builder/Dockerfile
+++ b/amphora-image-builder/Dockerfile
@@ -13,8 +13,9 @@ RUN apt-get update && \
 COPY ./ /opt/cloud-image-builders
 
 # Clone octavia and install its diskimage-create requirements
-RUN git clone https://opendev.org/openstack/octavia.git /opt/octavia \
- && pip3 install --no-cache-dir -r /opt/octavia/diskimage-create/requirements.txt
+RUN git clone https://opendev.org/openstack/octavia.git /opt/octavia && \
+ git --git-dir=/opt/octavia/.git checkout 08003bb7263aef0ff74d30dc1540bfe18d330f9a && \
+ pip3 install --no-cache-dir -r /opt/octavia/diskimage-create/requirements.txt
 
 COPY amphora-image-builder/entrypoint.sh entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/amphora-image-builder/build.sh
+++ b/amphora-image-builder/build.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# make a temporary cache for image building - easiest way to avoid out-of-space issues
+mkdir -p /tmp/octavia-cache
+
 # Move up a dir so we can include this git repo in the build
 # so any changes to the elements can be tested
 cd .. 
@@ -9,5 +12,7 @@ docker build -f amphora-image-builder/Dockerfile -t amphora-image-builder:local 
 
 # The Amphora builder requires privileged access to the host
 # to mount /proc and /sys
-docker run --privileged -v "$(pwd)/output":/output amphora-image-builder:local
+# -e OUTPUT_NAME=my-custom-image: to customize image name
+docker run --rm --privileged -v "$(pwd)/output:/output" amphora-image-builder:local
+
 cd amphora-image-builder

--- a/amphora-image-builder/elements/vm_baseline/install.d/90-run-vm_baseline
+++ b/amphora-image-builder/elements/vm_baseline/install.d/90-run-vm_baseline
@@ -2,23 +2,20 @@
 
 set -euo pipefail
 
-#install ansible
-apt-get update
-apt-get install python3-pip python3-venv -y
-/usr/bin/python3 -m venv /tmp/amphora-venv
-source /tmp/amphora-venv/bin/activate
-/usr/bin/python3 -m pip install ansible
-/usr/bin/git clone https://github.com/stfc/cloud-image-builders.git --depth=1
-cd cloud-image-builders
-
-apt-get install locale -y && apt-get clean all
-echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-echo "LANG=en_US.UTF-8" > /etc/locale.conf && \
-locale-gen en_US.UTF-8
-source /etc/default/locale
-
-apt-get install gpg-agent -y
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install gpg-agent ansible locales -y
+sudo apt-get clean all
 /usr/bin/gpg-agent --daemon
+
+/usr/bin/git clone https://github.com/stfc/cloud-image-builders.git --depth=1
+
+sudo locale-gen en_US.UTF-8
+
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+export LC_CTYPE=en_US.UTF-8
+
+cd cloud-image-builders
 
 hostname
 sed -i "s/hosts: default/hosts: localhost/g" os_builders/*.yml

--- a/amphora-image-builder/entrypoint.sh
+++ b/amphora-image-builder/entrypoint.sh
@@ -1,30 +1,23 @@
 #!/bin/bash
-
 set -euxo pipefail
+
+chmod 755 /opt/cloud-image-builders/amphora-image-builder/elements/vm_baseline/*/*
 
 DIB_RELEASE="jammy"  # Ubuntu 22.04
 export DIB_RELEASE
 
-cd /tmp
-python3 -m virtualenv octavia_disk_image_create
-# shellcheck source=/dev/null
-source octavia_disk_image_create/bin/activate
-
-git clone --depth=1 https://opendev.org/openstack/octavia
-DIB_REPO_PATH="$(pwd)/octavia"
-export DIB_REPO_PATH
-
-# run local config elements
-cd /opt/cloud-image-builders
-chmod 755 amphora-image-builder/elements/vm_baseline/*/*
-
-cd /tmp
 DIB_LOCAL_ELEMENTS="vm_baseline"
 export DIB_LOCAL_ELEMENTS
 
 DIB_LOCAL_ELEMENTS_PATH="/opt/cloud-image-builders/amphora-image-builder/elements"
 export DIB_LOCAL_ELEMENTS_PATH
 
-cd octavia/diskimage-create
-pip3 install -r requirements.txt
-./diskimage-create.sh -t qcow2 -m -o "/output/amphora-x64-$(date +"%Y-%m-%d")-haproxy.qcow2"
+DIB_REPO_PATH="/opt/octavia"
+export DIB_REPO_PATH
+
+export DIB_IMAGE_SIZE=10
+export DIB_MIN_TMPFS=0
+export TMPDIR=/tmp
+
+cd /opt/octavia/diskimage-create/
+./diskimage-create.sh -m -f -s $DIB_IMAGE_SIZE -o "/output/${OUTPUT_NAME:-amphora-x64-$(date +%Y-%m-%d)-haproxy}.qcow2"


### PR DESCRIPTION
changelog:

- use apt to install ansible rather than a virtualenv in vm_baseline

- don't need to setup a venv for octavia install
requirements - just install pip and use python that comes default in the container
- there were some missing dependencies - so add that to the dockerfile
- fix for setting locale in vm_baseline
- refactor the entrypoint and move a few commands to the docker build file so we can speed up builds
- allow setting custom output name
