### PR TITLE
07/04/2026 - bump capi images

### DIFF
--- a/cluster-api/versions/v1_30.json
+++ b/cluster-api/versions/v1_30.json
@@ -1,5 +1,0 @@
-{
-    "kubernetes_series": "v1.30",
-    "kubernetes_semver": "v1.30.14",
-    "kubernetes_deb_version": "1.30.14-1.1"
-}

--- a/cluster-api/versions/v1_33.json
+++ b/cluster-api/versions/v1_33.json
@@ -1,5 +1,5 @@
 {
     "kubernetes_series": "v1.33",
-    "kubernetes_semver": "v1.33.9",
-    "kubernetes_deb_version": "1.33.9-1.1"
+    "kubernetes_semver": "v1.33.10",
+    "kubernetes_deb_version": "1.33.10-1.1"
 }

--- a/cluster-api/versions/v1_34.json
+++ b/cluster-api/versions/v1_34.json
@@ -1,5 +1,5 @@
 {
     "kubernetes_series": "v1.34",
-    "kubernetes_semver": "v1.34.5",
-    "kubernetes_deb_version": "1.34.5-1.1"
+    "kubernetes_semver": "v1.34.6",
+    "kubernetes_deb_version": "1.34.6-1.1"
 }

--- a/os_builders/requirements.txt
+++ b/os_builders/requirements.txt
@@ -1,5 +1,5 @@
 # Newer Ansible versions do not support the Python 3.6 interpreter used by Rocky 8
 ansible==9.13.0
-ansible-core==2.16.14
+ansible-core==2.16.16
 # The most compatible OpenStack CLI version with OpenStack Yoga
 python-openstackclient==5.8.0

--- a/os_builders/roles/nubes_bootcontext/files/nubes-bootcontext.sh
+++ b/os_builders/roles/nubes_bootcontext/files/nubes-bootcontext.sh
@@ -19,5 +19,6 @@ do
 done;
 
 /usr/local/sbin/update_cloud_users.sh
+/usr/local/sbin/update_keys.sh
 
 systemctl restart wazuh-agent

--- a/os_builders/roles/nubes_bootcontext/tasks/main.yml
+++ b/os_builders/roles/nubes_bootcontext/tasks/main.yml
@@ -41,6 +41,5 @@
   become: true
   ansible.builtin.command:
     cmd: "systemctl enable nubes-boot.service"
-  become: true
 
 - include_tasks: update_cloud_users.yml

--- a/os_builders/roles/nubes_bootcontext/tasks/update_cloud_users.yml
+++ b/os_builders/roles/nubes_bootcontext/tasks/update_cloud_users.yml
@@ -10,12 +10,12 @@
     state: present
   become: true
 
-- name: Create cloud group for passwordless sudo
-  community.general.sudoers:
-    name: cloud
-    group: cloud
-    commands: ALL
-    nopassword: true
+- name: Create cloud sudoers file
+  copy:
+    dest: /etc/sudoers.d/cloud
+    content: "%cloud ALL=(ALL) NOPASSWD: ALL"
+    mode: "0440"
+    validate: "visudo -cf %s"
   become: true
 
 - name: Copy in update_cloud_users script

--- a/os_builders/roles/nubes_bootcontext/tasks/update_cloud_users.yml
+++ b/os_builders/roles/nubes_bootcontext/tasks/update_cloud_users.yml
@@ -14,8 +14,7 @@
   copy:
     dest: /etc/sudoers.d/cloud
     content: "%cloud ALL=(ALL) NOPASSWD: ALL"
-    mode: "0440"
-    validate: "visudo -cf %s"
+    mode: 0440
   become: true
 
 - name: Copy in update_cloud_users script

--- a/os_builders/roles/tidy_image/tasks/cleanup_sudoers.yml
+++ b/os_builders/roles/tidy_image/tasks/cleanup_sudoers.yml
@@ -1,5 +1,0 @@
-- name: Cleanout /etc/sudoers.d/cloud
-  file:
-    path: "/etc/sudoers.d/cloud"
-    state: absent
-  become: true

--- a/os_builders/roles/tidy_image/tasks/main.yml
+++ b/os_builders/roles/tidy_image/tasks/main.yml
@@ -15,10 +15,10 @@
 
 - include_tasks: reboot.yml
   when: in_container
-  
+
 - include_tasks: get_package_facts.yml
 - include_tasks: run_quattor.yml
-  when: ansible_distribution == "Rocky" 
+  when: ansible_distribution == "Rocky"
 - include_tasks: get_package_facts.yml
 - include_tasks: cleanout_tmp.yml
 - include_tasks: cleanout_rc_directories.yml
@@ -26,7 +26,7 @@
 - include_tasks: set_locale.yml
 - include_tasks: wazuh.yml
 - include_tasks: cleanup_quattor.yml
-  when: ansible_distribution == "Rocky" 
+  when: ansible_distribution == "Rocky"
 - include_tasks: run_pakiti.yml
 - include_tasks: cleanup_users.yml
 - include_tasks: cleanup_old_kernels.yml
@@ -37,4 +37,3 @@
 - include_tasks: logrotate.yml
 - include_tasks: clear_audit_log.yml
 - include_tasks: remove_shell_history.yml
-- include_tasks: cleanup_sudoers.yml

--- a/os_builders/roles/vm_baseline/tasks/ssh.yml
+++ b/os_builders/roles/vm_baseline/tasks/ssh.yml
@@ -4,6 +4,12 @@
     state: present
   become: true
 
+- name: Install wget
+  package:
+    name: wget
+    state: present
+  become: true
+
 - name: Enable root login for authorized admins
   block:
     - debug:
@@ -41,8 +47,6 @@
     group: cloud
     mode: 0700
   become: true
-
-
 
 - name: Copy authorized cloud admin keys into cloud's authorized_keys
   copy:


### PR DESCRIPTION

changelog:

update k8s patch versions - drop support for 1.30 as its eol
bump k8s builder submodule
bump ansible core
some tweaks to ansible to avoid python version issues between OS versions