### PR TITLE
BUG: Change build flavor to l6.c2

### DIFF
--- a/os_builders/CHANGELOG
+++ b/os_builders/CHANGELOG
@@ -10,3 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 
 - Added this CHANGELOG file to track changes to the images.
+
+### Changed
+- Changed image build flavor to l6.c2 to enable images to be used on VMs with less than 50GB disk.

--- a/os_builders/README.md
+++ b/os_builders/README.md
@@ -41,6 +41,7 @@ The pipeline consists of the following steps:
   ansible-playbook prep_builder.yml
   ```
 2. Create an applications credential (admin is only required to make images public)
+   > **NOTE:** The project you are building in must have access to the **l6.c2** flavor.
   ```shell
   # Either place app creds in directory
 

--- a/os_builders/build.pkr.hcl
+++ b/os_builders/build.pkr.hcl
@@ -17,7 +17,7 @@ locals {
 
 source "openstack" "builder" {
   domain_name       = "Default"
-  flavor            = "l3.nano"
+  flavor            = "l6.c2"
   security_groups   = ["default"]
   networks          = ["fa2f5ebe-d0e0-4465-9637-e9461de443f1"]  # Dev OpenStack Network ID
   image_visibility  = "private"


### PR DESCRIPTION
The l3.nano flavor has a disk size of 50GB. When Packer snapshots the VM to create our image it sets the "virtual_size" property to the size of the VM root disk. OpenStack won't let you build a VM with a smaller disk than the image "virtual_size". This prevents use from using the l6.c2 flavor as it has a disk size of 35GB. By building all images with the smallest (in this case l6.c2) flavor we have, it should make sure the images work for every other flavor.

Resolves issue #130