### PR TITLE
BUG: Fix nubes-boot loop with private IP

### DIFF
--- a/os_builders/CHANGELOG
+++ b/os_builders/CHANGELOG
@@ -13,3 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Changed image build flavor to l6.c2 to enable images to be used on VMs with less than 50GB disk.
+
+### Fixed
+- Fix user creation on VMs with 10.10 or 192.168 IP address.

--- a/os_builders/roles/nubes_bootcontext/files/nubes-bootcontext.sh
+++ b/os_builders/roles/nubes_bootcontext/files/nubes-bootcontext.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+set -xeuo pipefail
+
 hostname="networktest"
 
 while [[ "$hostname" == "networktest" ]];
 do
-    sleep 5s
+    
     ipaddress=$(hostname -I | sed "s/ //g")
 
     if [[ "$ipaddress" == "130."* ]] || [[ $ipaddress == "172."*  ]]; then
@@ -14,8 +16,14 @@ do
         else
             hostname="networktest";
         fi;
+        sleep 5s
+        ((c++)) && ((c==3)) && c=0 && break
 
+
+    else
+        break;
     fi;
+
 done;
 
 /usr/local/sbin/update_cloud_users.sh


### PR DESCRIPTION
Add a break to the while loop when the IP is not 130 or 172 and limit to 3 retries when changing hostname before continuing.

See commit message.


Resolves #126