### PR TITLE
MAINT: Use new username service for update_cloud_users.sh

### DIFF
--- a/os_builders/CHANGELOG
+++ b/os_builders/CHANGELOG
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Changed image build flavor to l6.c2 to enable images to be used on VMs with less than 50GB disk.
+- Changed update_cloud_users.sh to use the new username service. This script is more reslient to failures. [#138](https://github.com/stfc/cloud-image-builders/pull/138)
 
 ### Fixed
 - Fix user creation on VMs with 10.10 or 192.168 IP address.

--- a/os_builders/roles/nubes_bootcontext/files/update_cloud_users.sh
+++ b/os_builders/roles/nubes_bootcontext/files/update_cloud_users.sh
@@ -17,7 +17,7 @@ BASE_URLS=(
 
 OPENSTACK_URL=""
 for base in  "${BASE_URLS[@]}"; do
-    url="${base}/getusername?serverID=${INSTANCEID}"
+    url="${base}:9999/getusername?serverID=${INSTANCEID}"
     HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$url")
     if [[ $HTTP_CODE = 200 ]]; then
         OPENSTACK_URL="$url"
@@ -59,15 +59,15 @@ SSH_PUBLIC_KEY=$(jq -r .keys[0].data /mnt/context/openstack/latest/meta_data.jso
 
 groupadd wheel
 
-id -u "$ID" || useradd "$ID" -g wheel -m -s /bin/bash
-usermod "$ID" -a -G wheel,cloud
+id -u "$FEDID" || useradd "$FEDID" -g wheel -m -s /bin/bash
+usermod "$FEDID" -a -G wheel,cloud
 
-[[ -d /home/"$ID"/.ssh ]] || mkdir -p /home/"$ID"/.ssh
-chown "$ID" /home/"$ID"
-chown "$ID" /home/"$ID"/.ssh
-if [[ "$ID" == "$FEDID" ]]; then
-    if ! grep -qF "${SSH_PUBLIC_KEY//\\n/}" /home/"$ID"/.ssh/authorized_keys; then
-        echo "${SSH_PUBLIC_KEY//\\n/}" >> /home/"$ID"/.ssh/authorized_keys
+[[ -d /home/"$FEDID"/.ssh ]] || mkdir -p /home/"$FEDID"/.ssh
+chown "$FEDID" /home/"$FEDID"
+chown "$FEDID" /home/"$FEDID"/.ssh
+if [[ "$FEDID" == "$FEDFEDID" ]]; then
+    if ! grep -qF "${SSH_PUBLIC_KEY//\\n/}" /home/"$FEDID"/.ssh/authorized_keys; then
+        echo "${SSH_PUBLIC_KEY//\\n/}" >> /home/"$FEDID"/.ssh/authorized_keys
     fi
 fi
-chown "$ID" /home/"$ID"/.ssh/authorized_keys
+chown "$FEDID" /home/"$FEDID"/.ssh/authorized_keys

--- a/os_builders/roles/nubes_bootcontext/files/update_cloud_users.sh
+++ b/os_builders/roles/nubes_bootcontext/files/update_cloud_users.sh
@@ -9,6 +9,11 @@ fi
 
 INSTANCEID=$(jq -r .uuid /mnt/context/openstack/latest/meta_data.json)
 
+# fallback to dmidecode if needed
+if [[ -z "$INSTANCEID" ]]; then
+    INSTANCEID=$(dmidecode | awk -F': ' '/UUID/ {print tolower($2)}')
+fi
+
 BASE_URLS=(
     "https://openstack.stfc.ac.uk"
     "https://dev-openstack.stfc.ac.uk"
@@ -41,12 +46,6 @@ for _ in {1..3}; do
     if [[ -n "$FEDID" ]]; then
         break
     fi
-
-    # fallback to dmidecode if needed
-    if [[ -z "$INSTANCEID" ]]; then
-        INSTANCEID=$(dmidecode | awk -F': ' '/UUID/ {print tolower($2)}')
-    fi
-
     sleep 1
 done
 

--- a/os_builders/roles/nubes_bootcontext/files/update_cloud_users.sh
+++ b/os_builders/roles/nubes_bootcontext/files/update_cloud_users.sh
@@ -1,61 +1,73 @@
 #!/bin/bash
 
-if [[ -f /var/lock/firstboot ]] ;
-then
-    for i in packer packer-test;
-    do
-        id -u $i && userdel $i -r;
-    done
-    rm -f /var/lock/firstboot
+set -euxo pipefail
+
+mkdir -p /mnt/context
+if [[ ! -d "/mnt/context/openstack" ]]; then
+    mount /dev/sro /mnt/context
 fi
 
-[[ -d /mnt/context ]] || mkdir /mnt/context
-[[ -d /mnt/context/openstack ]] || mount /dev/sr0 /mnt/context
-INSTANCEID=$(jq .uuid /mnt/context/openstack/latest/meta_data.json | sed "s/\"//g")
+INSTANCEID=$(jq -r .uuid /mnt/context/openstack/latest/meta_data.json)
 
-if curl -s http://openstack.nubes.rl.ac.uk:9999/cgi-bin/get_username.sh?"$INSTANCEID" | grep ".";
-then
-    OPENSTACK_URL='openstack.nubes.rl.ac.uk'
-else
-    OPENSTACK_URL='dev-openstack.nubes.rl.ac.uk'
-fi
+BASE_URLS=(
+    "https://openstack.stfc.ac.uk"
+    "https://dev-openstack.stfc.ac.uk"
+)
 
-echo $OPENSTACK_URL
 
-FEDID_RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://$OPENSTACK_URL:9999/cgi-bin/get_username.sh?"$INSTANCEID")
-if [[ $FEDID_RESPONSE_CODE != 200 ]]; then
-    echo "$FEDID_RESPONSE_CODE expected 200"
-    exit
-fi
-
-FEDIDS=$(curl -s http://$OPENSTACK_URL:9999/cgi-bin/get_username_list.sh?"$INSTANCEID")
-FEDID=$(curl -s http://$OPENSTACK_URL:9999/cgi-bin/get_username.sh?"$INSTANCEID")
-
-while [ -z "$FEDID" ]
-   do
-    if [ -z "$INSTANCEID" ]
-    then
-        INSTANCEID=$(dmidecode | grep UUID | tr '[:upper:]' '[:lower:]' | sed "s/\\tuuid: //")
+OPENSTACK_URL=""
+for base in  "${BASE_URLS[@]}"; do
+    url="${base}/getusername?serverID=${INSTANCEID}"
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+    if [[ $HTTP_CODE = 200 ]]; then
+        OPENSTACK_URL="$url"
+        break
+    else
+        echo "Error Connecting to ${OPENSTACK_URL}: Expected 200 got ${HTTP_CODE}, trying another"
     fi
-    FEDID=$(curl -s http://$OPENSTACK_URL:9999/cgi-bin/get_username.sh?"$INSTANCEID")
-    ((c++)) && ((c==3)) && c=0 && break
-   done
+done
 
-SSH_PUBLIC_KEY=$(jq .keys[0].data /mnt/context/openstack/latest/meta_data.json | sed "s/\"//g")
+if [[ -z "$OPENSTACK_URL" ]]; then
+    echo "Failed to get valid OpenStack endpoint"
+    exit 1
+fi
+
+
+# --- Fetch FEDID with retries ---
+FEDID=""
+for _ in {1..3}; do
+    FEDID=$(curl -fs "$OPENSTACK_URL" || true)
+
+    if [[ -n "$FEDID" ]]; then
+        break
+    fi
+
+    # fallback to dmidecode if needed
+    if [[ -z "$INSTANCEID" ]]; then
+        INSTANCEID=$(dmidecode | awk -F': ' '/UUID/ {print tolower($2)}')
+    fi
+
+    sleep 1
+done
+
+if [[ -z "$FEDID" ]]; then
+    echo "Failed to retrieve FEDID from ${OPENSTACK_URL}"
+    exit 1
+fi
+
+SSH_PUBLIC_KEY=$(jq -r .keys[0].data /mnt/context/openstack/latest/meta_data.json)
 
 groupadd wheel
 
-for ID in $FEDID $FEDIDS; do
-    id -u "$ID" || useradd "$ID" -g wheel -m -s /bin/bash
-    usermod "$ID" -a -G wheel,cloud
+id -u "$ID" || useradd "$ID" -g wheel -m -s /bin/bash
+usermod "$ID" -a -G wheel,cloud
 
-    [[ -d /home/"$ID"/.ssh ]] || mkdir -p /home/"$ID"/.ssh
-    chown "$ID" /home/"$ID"
-    chown "$ID" /home/"$ID"/.ssh
-    if [[ "$ID" == "$FEDID" ]]; then
-        if ! grep -qF "${SSH_PUBLIC_KEY//\\n/}" /home/"$ID"/.ssh/authorized_keys; then
-            echo "${SSH_PUBLIC_KEY//\\n/}" >> /home/"$ID"/.ssh/authorized_keys
-        fi
+[[ -d /home/"$ID"/.ssh ]] || mkdir -p /home/"$ID"/.ssh
+chown "$ID" /home/"$ID"
+chown "$ID" /home/"$ID"/.ssh
+if [[ "$ID" == "$FEDID" ]]; then
+    if ! grep -qF "${SSH_PUBLIC_KEY//\\n/}" /home/"$ID"/.ssh/authorized_keys; then
+        echo "${SSH_PUBLIC_KEY//\\n/}" >> /home/"$ID"/.ssh/authorized_keys
     fi
-    chown "$ID" /home/"$ID"/.ssh/authorized_keys
-done
+fi
+chown "$ID" /home/"$ID"/.ssh/authorized_keys


### PR DESCRIPTION
Updating the script to use the new username service. The updates to this script make it much more resiliant to failing. For example it will retry 3 times. We have also made some QOL and readability fixes to generally improve it.

This is needed as the physical hardware hosting the current endpoint to get OpenStack users is being decomissioned.