### PR TITLE
ENH: Add builder for Ubuntu 26

### DIFF
--- a/os_builders/CHANGELOG
+++ b/os_builders/CHANGELOG
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 
 - Added this CHANGELOG file to track changes to the images.
+- Added the Ubuntu 26 builder. [#139](https://github.com/stfc/cloud-image-builders/pull/139)
 
 ### Changed
  Changed image build flavor to l6.c2 to enable images to be used on VMs with less than 50GB disk [#130](https://github.com/stfc/cloud-image-builders/issues/130)

--- a/os_builders/build.pkr.hcl
+++ b/os_builders/build.pkr.hcl
@@ -54,6 +54,12 @@ build {
     external_source_image_url = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
   }
   source "openstack.builder" {
+    name                      = "ubuntu-resolute"
+    image_name                = "ubuntu-resolute-26.04-nogui-${ local.date_suffix }"
+    ssh_username              = "ubuntu"
+    external_source_image_url = "https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-amd64.img"
+  }
+  source "openstack.builder" {
     name = "rocky-8"
     image_name = "rocky-8-nogui-${ local.date_suffix }"
     ssh_username = "rocky"


### PR DESCRIPTION
Allows us to build Ubuntu 26 for testing and eventually release.