### PR TITLE
BUG: Fix bugs in scripts

### DIFF
--- a/os_builders/roles/nubes_bootcontext/files/nubes-boot.service
+++ b/os_builders/roles/nubes_bootcontext/files/nubes-boot.service
@@ -6,6 +6,9 @@ Before=sshd.service
 [Service]
 WorkingDirectory=/usr/local/bin/
 ExecStart=/usr/local/sbin/nubes-bootcontext.sh
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/os_builders/roles/nubes_bootcontext/files/nubes-bootcontext.sh
+++ b/os_builders/roles/nubes_bootcontext/files/nubes-bootcontext.sh
@@ -17,8 +17,6 @@ do
             hostname="networktest";
         fi;
         sleep 5s
-        ((c++)) && ((c==3)) && c=0 && break
-
 
     else
         break;

--- a/os_builders/roles/nubes_bootcontext/files/update_cloud_users.sh
+++ b/os_builders/roles/nubes_bootcontext/files/update_cloud_users.sh
@@ -59,7 +59,7 @@ usermod "$FEDID" -a -G wheel,cloud
 [[ -d /home/"$FEDID"/.ssh ]] || mkdir -p /home/"$FEDID"/.ssh
 chown "$FEDID" /home/"$FEDID"
 chown "$FEDID" /home/"$FEDID"/.ssh
-if [[ "$FEDID" == "$FEDFEDID" ]]; then
+if [[ "$FEDID" == "$FEDID" ]]; then
     if ! grep -qF "${SSH_PUBLIC_KEY//\\n/}" /home/"$FEDID"/.ssh/authorized_keys; then
         echo "${SSH_PUBLIC_KEY//\\n/}" >> /home/"$FEDID"/.ssh/authorized_keys
     fi


### PR DESCRIPTION
There is a typo in update_cloud_users.sh where a variable is spelt wrong. This was missed in testing.

The retry loop in the nubes-bootcontext.sh does not work as intended. Removing this and let systemd handle the retries.