### PR TITLE
BUG: Don't fail if wheel exists

### DIFF
--- a/os_builders/roles/nubes_bootcontext/files/update_cloud_users.sh
+++ b/os_builders/roles/nubes_bootcontext/files/update_cloud_users.sh
@@ -51,7 +51,7 @@ fi
 
 SSH_PUBLIC_KEY=$(jq -r .keys[0].data /mnt/context/openstack/latest/meta_data.json)
 
-groupadd wheel
+getent group wheel > /dev/null || groupadd wheel
 
 id -u "$FEDID" || useradd "$FEDID" -g wheel -m -s /bin/bash
 usermod "$FEDID" -a -G wheel,cloud


### PR DESCRIPTION
As we have used set -e the script will fail on any error. This is safe and good practice but groupadd wheel normally fails as the group already exists. By adding the or operator || we can bypass the set -e and allow the script to continue.