### PR TITLE
Fix reboot and rl8

### DIFF
--- a/os_builders/CHANGELOG
+++ b/os_builders/CHANGELOG
@@ -11,8 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new builders for Rocky 8 and 9 AQ images. [#148](https://github.com/stfc/cloud-image-builders/pull/148)
 
 ### Changed:
+- Updated Ansible version for building. [#144](https://github.com/stfc/cloud-image-builders/pull/144)
+- Created separate requirements file for RL8 image builds. [#153](https://github.com/stfc/cloud-image-builders/pull/153)
 
 ### Fixed:
+- Ubuntu 22 stuck at reboot when building image. [#153](https://github.com/stfc/cloud-image-builders/pull/153)
 
 ## [0.1.0]
 

--- a/os_builders/README.md
+++ b/os_builders/README.md
@@ -37,6 +37,7 @@ The pipeline consists of the following steps:
   cd cloud-image-builders/os_builders
 
   pip install -r requirements.txt
+  # If you are building the RL8 image use requirements-rl8.txt
 
   ansible-playbook prep_builder.yml
   ```

--- a/os_builders/requirements-rl8.txt
+++ b/os_builders/requirements-rl8.txt
@@ -1,0 +1,4 @@
+ansible==9.13.0
+ansible-core==2.16.16
+# The most compatible OpenStack CLI version with OpenStack Yoga
+python-openstackclient==5.8.0

--- a/os_builders/roles/tidy_image/tasks/reboot.yml
+++ b/os_builders/roles/tidy_image/tasks/reboot.yml
@@ -1,8 +1,6 @@
 - name: Reboot machine
   ansible.builtin.reboot:
-    reboot_command: "shutdown -r"
-    post_reboot_delay: 30
-    connect_timeout: 3600
+    pre_reboot_delay: 4
   become: true
 
   


### PR DESCRIPTION
Ubuntu 22 is getting stuck when rebooting. This used to be intermittent but is not consistently not working. Changing the reboot task seems to fix it.

The ansible version was updated in https://github.com/stfc/cloud-image-builders/pull/144 for K8s but this broke RL8. So I have added a separate RL8 requirements.txt file to build Rocky 8.

Completes https://stfc.atlassian.net/browse/CLDSCRM-3942